### PR TITLE
Audit thread

### DIFF
--- a/Gatekeeper/Gatekeeper.csproj
+++ b/Gatekeeper/Gatekeeper.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="3.10.0" />
+    <PackageReference Include="Discord.Net" Version="3.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="MySql.Data" Version="8.0.32.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Gatekeeper/Program.cs
+++ b/Gatekeeper/Program.cs
@@ -13,7 +13,7 @@ namespace Gatekeeper
 {
     class Program
     {
-		public const string VERSION = "2.0.0";
+		public const string VERSION = "2.1.0";
 
 		private DiscordSocketClient _client;
 		private CommandService _commands;

--- a/Gatekeeper/Services/AuditService.cs
+++ b/Gatekeeper/Services/AuditService.cs
@@ -20,7 +20,7 @@ namespace Gatekeeper.Services
         private readonly ConfigService _config;
         public List<ulong> IgnoredChannelIds { get; }
         
-        // List of tuples used to compare difference in roles 
+        // List of users used to compare difference in roles
         private readonly List<SocketGuildUser> cachedUsers = new List<SocketGuildUser>();
         private readonly List<SocketGuildUser> updatedUsers = new List<SocketGuildUser>();
 
@@ -37,7 +37,7 @@ namespace Gatekeeper.Services
             _client.UserLeft += LogUserLeft;
 
             // To reduce audit spam for role changes (which often happen in bulk) we spawn a thread to
-            // dispatch bunched changes every 10 minutes
+            // dispatch bunched changes every so often
             Thread thread = new Thread(DispatchRoleChanges);
             thread.Start();
 


### PR DESCRIPTION
Completed functionality for grouped role change audit dispatching. Every single role change no longer triggers an audit to be logged, changes in user's roles will be logged every ~2 minutes.